### PR TITLE
Add dispatchModule handler to handle module-specific requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,18 +22,19 @@
     "bluebird": "1.0.8"
   },
   "devDependencies": {
+    "chai": "^1.9.0",
     "forever": "^0.10.11",
-    "grunt-mocha-test": "^0.10.0",
     "grunt": "^0.4.4",
-    "grunt-contrib-jshint": "^0.9.2",
     "grunt-contrib-concat": "^0.3.0",
+    "grunt-contrib-cssmin": "^0.9.0",
+    "grunt-contrib-jshint": "^0.9.2",
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-contrib-cssmin": "^0.9.0",
+    "grunt-jsdoc": "^0.5.7",
+    "grunt-mocha-test": "^0.10.0",
     "grunt-nodemon": "^0.2.1",
     "grunt-shell": "^0.6.4",
     "mocha": "^1.17.1",
-    "chai": "^1.9.0",
     "supertest": "^0.10.0"
   },
   "scripts": {

--- a/server/app/controllers/controller.js
+++ b/server/app/controllers/controller.js
@@ -1,3 +1,7 @@
+/**
+* @module auth controller
+ */
+
 var User = require('../models/model');
 var util = require('../lib/utility');
 
@@ -13,6 +17,44 @@ exports.renderIndex = function (req, res) {
   res.render('index');
 };
 
+/**
+ * This handler stores username into req.session and redirects it to the main index page
+ *
+ * @param req
+ * @param res
+ */
 exports.login = function (req, res) {
   util.createSession(req, res, req.body.username);
+};
+
+/**
+ * Handle module-specific request to appropriate route based on whether a user has auth rule set up or not.
+ * If the user already has a specified auth rule defined, we redirect the request to /module/<module_name>/auth, otherwise to 'module/<module_name>/setup'
+ *
+ * @param req
+ * @param res
+ */
+exports.dispatchModule = function (req, res) {
+  var username = req.session.user;
+  var module = req.params.module;
+
+  User.findOne({username: username})
+    .exec(function(err, user) {
+      if (err) {
+        console.error(err);
+        res.redirect('login');
+      }
+
+      if (user) {
+        // TODO: This is a temp fix.  Once we have a working authentication module, we will invoke its module here
+        if (user['module']) {
+          res.render('face-auth');
+        } else {
+          res.render('face-setup');
+        }
+      } else {
+        console.log('Use account does not exist');
+        res.redirect('/login');
+      }
+    });
 };

--- a/server/server-config.js
+++ b/server/server-config.js
@@ -1,6 +1,8 @@
 var express = require('express');
 var partials = require('express-partials');
 var handler = require('./app/controllers/controller');
+var util = require('./app/lib/utility');
+
 var app = express();
 
 // connect to MongoDB
@@ -19,6 +21,8 @@ app.configure(function() {
 /*
   Define all routes here
  */
+app.get('/module/:module', util.checkUser, handler.dispatchModule);
+
 app.get('/login', handler.loginForm);
 app.post('/login', handler.login);
 app.get('/index', handler.renderIndex);

--- a/server/views/face-auth.ejs
+++ b/server/views/face-auth.ejs
@@ -1,0 +1,2 @@
+<h2>Facial Recognition Authentication</h2>
+<div></div>

--- a/server/views/face-setup.ejs
+++ b/server/views/face-setup.ejs
@@ -1,0 +1,2 @@
+<h2>Set up Facial Recognition Authentication Rule</h2>
+<div></div>


### PR DESCRIPTION
Add a new route and handler to handle module-specific requests.  This handler makes a query and see if a given user already has a specified auth rule set up or not.  If so, we'll redirect the request to /module_name/auth'.  Otherwise, '/module_name/setup'. 

Please note that I added two ejs files for face authentication just to test out this logic.  We can delete or move these files once we have a working auth module ready.

@krulwich, @suprbh, @ceg1236 - please review.
