### PR TITLE
Pass in module variable, instead of a string literal

### DIFF
--- a/server/app/controllers/controller.js
+++ b/server/app/controllers/controller.js
@@ -63,7 +63,7 @@ exports.dispatchModule = function (req, res) {
 
       if (user) {
         // TODO: This is a temp fix.  Once we have a working authentication module, we will invoke its module here
-        if (user['module']) {
+        if (user[module]) {
           res.render('face-auth');
         } else {
           res.render('face-setup');


### PR DESCRIPTION
I didn't meant to pass in a string literal to look up auth sub-document in User document.  Pass in module variable should work now.

@krulwich, @suprbh, @ceg1236 
