### PR TITLE
Store a username into a session instead of whole User object

### DIFF
--- a/server/app/controllers/controller.js
+++ b/server/app/controllers/controller.js
@@ -35,10 +35,12 @@ exports.login = function (req, res) {
           if( err ){
             return res.send(500, err);
           }
-          util.createSession(req, res, newUser);
+          util.createSession(req, res, username);
         });
       } else {
-        util.createSession(req, res, newUser);
+        // TODO: We should revisit this logic as redirecting to main index page blindly seems a bit strange
+        // I think it's perfectly acceptable to ask a new user to provide username/password to create their account here
+        util.createSession(req, res, username);
       }
     });
 };


### PR DESCRIPTION
This is a fix to https://github.com/mountain-device/easyauth/issues/47

Store only a username into a session, not the whole User object, as else statement won't be a User object, which causes this bug.

@krulwich, @suprbh, @ceg1236 
