### PR TITLE
Change route logic to redirect to module-specific URL

### DIFF
--- a/server/app/controllers/controller.js
+++ b/server/app/controllers/controller.js
@@ -4,6 +4,7 @@
 
 var User = require('../models/model');
 var util = require('../lib/utility');
+var path = require('path');
 
 exports.loginForm = function (req, res) {
   res.render('login');
@@ -64,12 +65,8 @@ exports.dispatchModule = function (req, res) {
       }
 
       if (user) {
-        // TODO: This is a temp fix.  Once we have a working authentication module, we will invoke its module here
-        if (user[module]) {
-          res.render('face-auth');
-        } else {
-          res.render('face-setup');
-        }
+        var url = (user[module]) ? path.join(module, 'auth'): path.join(module, 'setup');
+        res.redirect(url);
       } else {
         console.log('Use account does not exist');
         res.redirect('/login');

--- a/server/server-config.js
+++ b/server/server-config.js
@@ -23,17 +23,16 @@ app.configure(function() {
  */
 app.get('/module/:module', util.checkUser, handler.dispatchModule);
 
-app.get('/login', handler.loginForm);
-app.post('/login', handler.login);
-app.get('/index', handler.renderIndex);
-app.get('/*', handler.loginForm);
-//app.get('/*', handler.loginForm);
-
-app.get('/modules/password', function(req, res){
-  var passwordModule = require('./modules/passwordModule/auth.js');
+/* Password module routes */
+app.get('/password/:action', util.checkUser, function(req, res){
+  var passwordModule = require('./modules/password/auth.js');
   var html = passwordModule.setupRender();
   res.send(html);
 });
 
+app.get('/login', handler.loginForm);
+app.post('/login', handler.login);
+app.get('/index', handler.renderIndex);
+app.get('/*', handler.loginForm);
 
 module.exports = app;


### PR DESCRIPTION
We now redirect to module specific route (either setup or auth) depending on whether a user account exists or not.  After redirect, a module should take over and handle this request.  This also requires adding new module-specific routes (see password route in server-config.js).

@krulwich, @suprbh, @ceg1236 
